### PR TITLE
Remove Libtool `.la` files from Windows packages [skip travis] [skip circle]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,7 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_c_compilervs2008
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
-
-    - CONFIG: win_c_compilervs2015
+    - CONFIG: win_
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -1,4 +1,2 @@
-c_compiler:
-- vs2008
 m2w64_c_compiler:
 - m2w64-toolchain

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -1,4 +1,0 @@
-c_compiler:
-- vs2015
-m2w64_c_compiler:
-- m2w64-toolchain

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,12 @@ else
     uprefix="$PREFIX"
 fi
 
+# Cf. https://github.com/conda-forge/staged-recipes/issues/673, we're in the
+# process of excising Libtool files from our packages. Existing ones can break
+# the build while this happens. We have "/." at the end of $uprefix to be safe
+# in case the variable is empty.
+find $uprefix/. -name '*.la' -delete
+
 # On Windows we need to regenerate the configure scripts.
 if [ -n "$CYGWIN_PREFIX" ] ; then
     am_version=1.15 # keep sync'ed with meta.yaml
@@ -42,6 +48,7 @@ fi
 export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
 configure_args=(
     --prefix=$mprefix
+    --disable-static
     --disable-dependency-tracking
     --disable-selective-werror
     --disable-silent-rules
@@ -54,9 +61,6 @@ make check
 
 rm -rf $uprefix/share/man
 
-# Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
-if [ -z "$CYGWIN_PREFIX" ] ; then
-    for lib_ident in Xfixes; do
-        rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
-    done
-fi
+# Remove any new Libtool files we may have installed. It is intended that
+# conda-build will eventually do this automatically.
+find $uprefix/. -name '*.la' -delete

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -47,8 +47,6 @@ test:
     - test -f $PREFIX/lib/lib{{ lib_ident }}.dylib  # [osx]
     - test -f $PREFIX/lib/lib{{ lib_ident }}.so  # [linux]
     - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.dll.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.la exit /b 1  # [win]
     - if not exist %PREFIX%/Library/bin/msys-{{ lib_ident }}-*.dll exit /b 1  # [win]
     {% endfor %}
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]


### PR DESCRIPTION
Going through and removing the Libtool `.la` files from the X.org Windows packages, in line with the new policy ([discussion](https://github.com/conda-forge/staged-recipes/issues/673)).

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.
